### PR TITLE
ci: enforce lint strict for 6DQ G1 compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint src/ tests/",
+    "lint": "eslint --max-warnings=0 src/ tests/",
     "build": "bash scripts/build.sh",
     "test:e2e": "node tests/e2e/extension.e2e.js",
     "prepare": "husky"


### PR DESCRIPTION
Adds `--max-warnings=0` to eslint for strict lint enforcement.

6DQ compliance: G1 (lint strict) → enables Tier B.