### PR TITLE
fix(deps): resolve osv-scanner CI failure (basic-ftp + ip-address)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hooky",
       "dependencies": {
-        "basic-ftp": "5.3.0",
+        "basic-ftp": "^5.3.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -20,7 +20,7 @@
     },
   },
   "overrides": {
-    "basic-ftp": "^5.2.2",
+    "basic-ftp": "^5.3.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
   },
@@ -267,7 +267,7 @@
 
     "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw=="],
 
-    "basic-ftp": ["basic-ftp@5.3.0", "", {}, "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="],
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -75,3 +75,8 @@ reason = "Indirect: vite via vitest (dev-only, no production server exposure)"
 [[IgnoredVulns]]
 id = "GHSA-v2wj-q39q-566r"
 reason = "Indirect: vite via vitest (dev-only, no production server exposure)"
+
+# ip-address - indirect via 6to4/socks via cloudflared (CIDR validation, low risk in CI/build context)
+[[IgnoredVulns]]
+id = "GHSA-v2v4-37r5-5v8g"
+reason = "Indirect: ip-address via transitive deps (CIDR string handling, no untrusted input in our usage)"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
-    "basic-ftp": "^5.2.2",
+    "basic-ftp": "^5.3.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10"
   },
@@ -40,6 +40,6 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "basic-ftp": "5.3.0"
+    "basic-ftp": "^5.3.0"
   }
 }


### PR DESCRIPTION
Fix CI L1+G1+G2 osv-scanner failure on main.

## Changes
- **basic-ftp**: bump `5.3.0` → `5.3.1` (direct dep, fixes High GHSA-rpmf-866q-6p89)
- **ip-address**: add osv ignore for GHSA-v2v4-37r5-5v8g (transitive via cloudflared/socks proxy chain; CIDR validation, no untrusted input in our usage)

## Validation
- `osv-scanner scan --lockfile=bun.lock --config=osv-scanner.toml` → No issues found
- `bun run build` ✅
- `bun run test` ✅ (277/277)
