### PR TITLE
fix(security): pin ws and brace-expansion via overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,8 +21,10 @@
   },
   "overrides": {
     "basic-ftp": "^6.0.1",
+    "brace-expansion": "^5.0.6",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
+    "ws": "^8.20.1",
   },
   "packages": {
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
     "basic-ftp": "^6.0.1",
+    "brace-expansion": "^5.0.6",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

- Adds `overrides` entries for `ws ^8.20.1` and `brace-expansion ^5.0.6` to package.json to resolve two transitive moderate CVEs that have no direct upgrade path.
- Locks resolve to `ws@8.21.0` (already satisfied by `puppeteer-core@25.1.0`'s declared `ws@^8.21.0`, but kept as a forward-regression guard) and `brace-expansion@5.0.6` (forced through `minimatch -> eslint`).
- This branch carries a single commit on top of `main`; ahead 1 / behind 0, no conflicts.

## Vulnerabilities resolved

- `ws` — [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (uninitialized memory disclosure)
- `brace-expansion` — [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) (DoS via large numeric range)

Closes #16
Closes #21

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run test` — 14 files / 277 passed
- [x] `bun run lint` — clean (`--max-warnings=0`)
- [x] `bun run build` — `dist/hooky-1.1.1.zip` 180K
- [x] `bun run test:coverage` — 98.48% stmts / 95.94% branches / 95.65% funcs / 99.69% lines
- [x] `osv-scanner --config=osv-scanner.toml --lockfile=bun.lock` — No issues found
- [ ] `bun run test:e2e` — not exercised; requires Chrome 149 which isn't provisioned in this environment