### PR TITLE
chore(deps): bump puppeteer 25.2.0 → 25.2.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "globals": "17.7.0",
         "husky": "^9.1.7",
         "jsdom": "29.1.1",
-        "puppeteer": "25.2.0",
+        "puppeteer": "25.2.1",
         "vitest": "4.1.9",
       },
     },
@@ -426,9 +426,9 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "puppeteer": ["puppeteer@25.2.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.5", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "lilconfig": "^3.1.3", "puppeteer-core": "25.2.0", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-JPMPd/2+lgdkLhEyPqH895oR3ccMt1wSra6oewgjjTuLmo2s9zPZpKXQTFEIiA/fMKpiL01kjU3+2zPEReRWNg=="],
+    "puppeteer": ["puppeteer@25.2.1", "", { "dependencies": { "@puppeteer/browsers": "3.0.5", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "lilconfig": "^3.1.3", "puppeteer-core": "25.2.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-2D5RMkQH9FRhDU57a1/jV9xWoxqZvUjaZOYjAAPdRCEY8A01V5sxzyGOMs8XiKU9fPF91SOSwNYpHRu5SD958g=="],
 
-    "puppeteer-core": ["puppeteer-core@25.2.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.5", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-jGhuGAlkgOcbyGRc0Cm9b/y4vvqoxhyAyl6a1diVe8F3sHsgTaQ60QQT5F3rGegTZV3prysgHVc+0LsvPZo3GA=="],
+    "puppeteer-core": ["puppeteer-core@25.2.1", "", { "dependencies": { "@puppeteer/browsers": "3.0.5", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-MwEZ4FFGJ1ZLOmu/04eISxoEMKtCnHyJBRFfgpwPPSYNG6gT6Xw1laNziFSV7uwDcx3jK+ATYIo9SfOd8Uhc3w=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "globals": "17.7.0",
     "husky": "^9.1.7",
     "jsdom": "29.1.1",
-    "puppeteer": "25.2.0",
+    "puppeteer": "25.2.1",
     "vitest": "4.1.9"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Bump `puppeteer` devDependency from `25.2.0` → `25.2.1` (patch release).
- `puppeteer` is only used by `tests/e2e/extension.e2e.js`; no production code touched.
- Reinstalled deps from a clean `node_modules` to avoid stale cache.

## Test plan

- [x] `bun run lint`
- [x] `bun run test` — 277/277 pass
- [x] `bun run test:e2e` — 32 pass, 2 fail. Both failures (`Popup: Template select shows correct name`, `Rules: Template dropdown contains 'E2E Test Hook'`) reproduce identically on `25.2.0` baseline → **pre-existing, unrelated to this upgrade**.

Closes nocoo/hooky#36
