### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

Add a root `.npmrc` establishing the supply-chain security baseline for the project:

- Pin registry to the official `https://registry.npmjs.org/` (anti-phishing source)
- Enforce lockfile integrity: `save-exact=true`, `package-lock=true`
- Require `engine-strict=true` to prevent Node/npm version drift
- Enable `audit=true` with `audit-level=high`; silence `fund` noise

Notes:
- **Not adding `ignore-scripts=true`** — would break postinstall for prisma/esbuild/puppeteer etc.; script-poisoning defense will land later via a `trustedDependencies` allowlist.
- The project primarily uses bun. bun honors a subset of `.npmrc` (registry, audit, ignore-scripts); `save-exact` and `engine-strict` are inert for bun but still guard occasional `npm`/`npx` usage.

## Scope

- Adds only the root `.npmrc` (21 lines).
- No changes to `package.json`, `bun.lock`, `bunfig.toml`, CI, hooks, or any other file.
- No `bun install` / `npm install` was run — this file does not affect existing dependencies.

## Test plan

- [ ] CI pipeline passes on the PR
- [ ] `git diff main...HEAD --name-status` shows only `A .npmrc`
