### PR TITLE
STU-2086: chore(deps): bump brace-expansion 5.0.6 → 5.0.7 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "basic-ftp": "^6.0.1",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.0.7",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
@@ -250,7 +250,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
     "basic-ftp": "^6.0.1",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.0.7",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",


### PR DESCRIPTION
## Summary

- Bump `overrides.brace-expansion` from `^5.0.6` to `^5.0.7`
- Fixes high-severity ReDoS advisory [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups
- `brace-expansion` is a transitive dep (`minimatch` → `eslint`); the existing root `overrides` pin is the fix surface

## Test plan

- [x] `bun install --frozen-lockfile` — 202 packages, lockfile resolves `brace-expansion@5.0.7`
- [x] `bun run test` — 14 files / 277 passed
- [x] `bun run lint` — 0 warnings
- [x] Coverage: 98.48% / 95.94% / 95.65% / 99.69% (no regression)

Closes #48
