### PR TITLE
chore(deps): security bumps — brace-expansion 5.0.8, postcss 8.5.23

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "basic-ftp": "^6.0.1",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
@@ -250,7 +250,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "undici": "^7.28.0",
     "vite": "^7.3.5",
     "ws": "^8.20.1",
@@ -396,7 +396,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -420,7 +420,7 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "undici": "^7.28.0",
     "vite": "^7.3.5",
     "ws": "^8.20.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
     "basic-ftp": "^6.0.1",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",


### PR DESCRIPTION
## Summary

Two transitive-dep security bumps via root `overrides`:

- `brace-expansion` 5.0.7 → 5.0.8 — fixes **GHSA-mh99-v99m-4gvg** (high, DoS via unbounded expansion). Pulled in through `eslint → minimatch`.
- `postcss` 8.5.13 → 8.5.23 — fixes **GHSA-r28c-9q8g-f849** (high, path traversal in previous source map auto-loading). Pulled in through `vite → vitest`. `nanoid` floated 3.3.11 → 3.3.16 as postcss's transitive requirement.

Closes #50
Closes #51

## Test plan

- [x] `bun install` (frozen lockfile install)
- [x] `bun run test` — 14 files / 277 tests passing
- [x] `bun run lint` — clean
- [x] Coverage thresholds met: 98.48% / 95.94% / 95.65% / 99.69%
- [x] Independent verify by Reviewer-03 passed