### PR TITLE
chore(deps): bump basic-ftp 6.0.2 → 6.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hooky",
       "dependencies": {
-        "basic-ftp": "6.0.2",
+        "basic-ftp": "6.1.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -20,7 +20,7 @@
     },
   },
   "overrides": {
-    "basic-ftp": "^6.0.2",
+    "basic-ftp": "^6.1.0",
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
@@ -242,7 +242,7 @@
 
     "balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
-    "basic-ftp": ["basic-ftp@6.0.2", "", {}, "sha512-R6+2Z0XWky9zW2iGyUC8OYG91rwSU+zWS1Iiai9lC31vC1nuHOUbBMeOG5yv5+oZOqnqKvggVkE+UbAoJWWuAg=="],
+    "basic-ftp": ["basic-ftp@6.1.0", "", {}, "sha512-g/feoL2nTNU15EsU1az9xMRhnaIlG3QUMLUSRl6qDr7LmiYafOrokfd5Hb8LCveELjkiihVUCY/jROXat2FpFQ=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
-    "basic-ftp": "^6.0.2",
+    "basic-ftp": "^6.1.0",
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
@@ -45,6 +45,6 @@
     "vitest": "4.1.10"
   },
   "dependencies": {
-    "basic-ftp": "6.0.2"
+    "basic-ftp": "6.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Bump `basic-ftp` 6.0.2 → 6.1.0 (minor).

- `package.json`: `dependencies.basic-ftp` 6.0.2 → 6.1.0 and matching `overrides.basic-ftp` `^6.0.2` → `^6.1.0` (without syncing the override, resolution is pinned back to 6.0.2).
- `bun.lock`: refreshed the three `basic-ftp` entries; integrity updated to the upstream 6.1.0 sha512.

Upstream 6.1.0 focuses on upload integrity protection; no Node engine bump. This project does not directly call the basic-ftp API — the package is a transitive `puppeteer` dep — so no source changes are needed.

Closes nocoo/hooky#59

## Test plan

- [x] `bun install --frozen-lockfile` succeeds
- [x] `bun run test` — 14 files / 277 passed
- [x] `bun run test:coverage` — 98.48% statements / 95.94% branches / 95.65% functions / 99.69% lines
- [x] `bun run lint` — clean (`eslint --max-warnings=0`)
- [x] `bun run build` — succeeds
- [x] `rg -c '", "https' bun.lock` = 0 (no mirror URL contamination)
