### PR TITLE
chore(deps): bump globals + basic-ftp

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hooky",
       "dependencies": {
-        "basic-ftp": "6.1.0",
+        "basic-ftp": "6.2.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -20,7 +20,7 @@
     },
   },
   "overrides": {
-    "basic-ftp": "^6.1.0",
+    "basic-ftp": "^6.2.0",
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
@@ -242,7 +242,7 @@
 
     "balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
-    "basic-ftp": ["basic-ftp@6.1.0", "", {}, "sha512-g/feoL2nTNU15EsU1az9xMRhnaIlG3QUMLUSRl6qDr7LmiYafOrokfd5Hb8LCveELjkiihVUCY/jROXat2FpFQ=="],
+    "basic-ftp": ["basic-ftp@6.2.0", "", {}, "sha512-H8eLjhoYPbOI717FLP8fGE7XInkMI7Ucj/ft0fp1avABtSiV5Bb2kYzScnOqlvJZs/KJZypr9Mp5zJmhaPFAEg=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "4.1.10",
         "eslint": "10.8.0",
-        "globals": "17.8.0",
+        "globals": "17.9.0",
         "husky": "^9.1.7",
         "jsdom": "30.0.1",
         "puppeteer": "25.4.0",
@@ -326,7 +326,7 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@17.8.0", "", {}, "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ=="],
+    "globals": ["globals@17.9.0", "", {}, "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nocoo/hooky#readme",
   "overrides": {
-    "basic-ftp": "^6.1.0",
+    "basic-ftp": "^6.2.0",
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "picomatch": "^4.0.4",
@@ -45,6 +45,6 @@
     "vitest": "4.1.10"
   },
   "dependencies": {
-    "basic-ftp": "6.1.0"
+    "basic-ftp": "6.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",
-    "globals": "17.8.0",
+    "globals": "17.9.0",
     "husky": "^9.1.7",
     "jsdom": "30.0.1",
     "puppeteer": "25.4.0",


### PR DESCRIPTION
## Summary

- Bump `globals` 17.8.0 → 17.9.0 (devDep) — Closes #62
- Bump `basic-ftp` 6.1.0 → 6.2.0 (dep + override) — Closes #61

Each package bumped in its own atomic commit.

## Verification

- `bun run test` → 14 files / 277 passed
- `bun run lint` → clean (max-warnings=0)
- Coverage: 98.48% statements / 95.94% branches / 95.65% functions / 99.69% lines
- `bun.lock` no mirror-URL pollution

## Test plan

- [x] Unit tests pass
- [x] Lint clean
- [ ] CI green