### PR TITLE
STU-2971: fix nanoid security vulnerability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
     "basic-ftp": "^6.2.0",
     "brace-expansion": "^5.0.9",
     "esbuild": "^0.28.1",
+    "nanoid": "^3.3.17",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
     "undici": "^8.9.0",
@@ -392,7 +393,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "basic-ftp": "^6.2.0",
     "brace-expansion": "^5.0.9",
     "esbuild": "^0.28.1",
+    "nanoid": "^3.3.17",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
     "undici": "^8.9.0",


### PR DESCRIPTION
## Summary

- constrain the transitive `nanoid` dependency to the fixed 3.x release line
- regenerate `bun.lock` from `nanoid@3.3.16` to `nanoid@3.3.18`
- preserve the existing `postcss → nanoid` dependency relationship without adding a direct dependency

## Validation

- `bun install --frozen-lockfile`
- `bun run test:coverage` — 277 tests passed
- `bun run lint`
- `bun run build`
- `bun run test:e2e` — 34 checks passed
- `bun audit` no longer reports GHSA-2v37-7h3g-55p8

Closes #71
