### PR TITLE
STU-3332: chore(deps): bump globals 17.9.0 → 17.10.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "4.1.10",
         "eslint": "10.8.1",
-        "globals": "17.9.0",
+        "globals": "17.10.0",
         "husky": "^9.1.7",
         "jsdom": "30.0.1",
         "puppeteer": "25.5.0",
@@ -327,7 +327,7 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@17.9.0", "", {}, "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg=="],
+    "globals": ["globals@17.10.0", "", {}, "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.1",
-    "globals": "17.9.0",
+    "globals": "17.10.0",
     "husky": "^9.1.7",
     "jsdom": "30.0.1",
     "puppeteer": "25.5.0",


### PR DESCRIPTION
## Summary
- Bump devDependency `globals` from 17.9.0 to 17.10.0
- Update `bun.lock` integrity/resolution to match

Closes #74

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run test` (14 files / 277 tests)
- [x] `bun run lint` (`--max-warnings=0`)
- [x] Reviewer-01 approved local commit `a4e5ac5`

Multica: STU-3332