### PR TITLE
chore(deps): bump globals 17.10.0 → 17.11.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "4.1.10",
         "eslint": "10.8.1",
-        "globals": "17.10.0",
+        "globals": "17.11.0",
         "husky": "^9.1.7",
         "jsdom": "30.0.1",
         "puppeteer": "25.6.0",
@@ -327,7 +327,7 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@17.10.0", "", {}, "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA=="],
+    "globals": ["globals@17.11.0", "", {}, "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.1",
-    "globals": "17.10.0",
+    "globals": "17.11.0",
     "husky": "^9.1.7",
     "jsdom": "30.0.1",
     "puppeteer": "25.6.0",


### PR DESCRIPTION
## Summary
- Bump `globals` from 17.10.0 to 17.11.0
- Lockfile updated via bun; no application code changes

Closes #79
Closes STU-3408

## Test plan
- [x] `bun run test` — 14 files / 277 tests passed
- [x] `bun run lint` — 0 warnings
- [x] `bun run test:coverage` — thresholds met (Stmts 98.48% / Branch 95.94% / Funcs 95.65% / Lines 99.69%)
- [x] Reviewer-01 independent verification passed